### PR TITLE
Use require stanza instead of script[src=""]

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@
 	</head>
 	<body>
 		<div id="app" style="position: absolute; top:0; bottom:0; left:0; right:0;"></div>
-		<script src="dist/index.js"></script>
+		<script>require('./dist/index.js')</script>
 	</body>
 </html>


### PR DESCRIPTION
* relative require from script-included js did not work before
* fix by using a top-level require stanza instead as per https://github.com/electron-userland/electron-compile/issues/60